### PR TITLE
Set schema compiler options

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -70,6 +70,9 @@ class Connection implements Serializable
     /** @var    array  Compiler options */
     protected $compilerOptions = array();
 
+    /** @var    array   Schema compiler options */
+    protected $schemaCompilerOptions = array();
+    
     /**
      * Constructor
      * 
@@ -208,6 +211,7 @@ class Connection implements Serializable
     public function setWrapperFormat($wrapper)
     {
         $this->compilerOptions['wrapper'] = $wrapper;
+        $this->schemaCompilerOptions['wrapper'] = $wrapper;
         return $this;
     }
 
@@ -339,6 +343,8 @@ class Connection implements Serializable
                 default:
                     throw new \Exception('Schema not supported yet');
             }
+
+            $this->schemaCompiler->setOptions($this->schemaCompilerOptions);
         }
 
         return $this->schemaCompiler;

--- a/lib/Schema/Compiler.php
+++ b/lib/Schema/Compiler.php
@@ -56,6 +56,19 @@ class Compiler
     }
 
     /**
+     * Sets compiler options
+     * 
+     * @param   array   $options
+     */
+    public function setOptions(array $options)
+    {
+        foreach ($options as $name => $value) {
+            $this->{$name} = $value;
+        }
+    }
+
+
+    /**
      * @param   string  $name
      * 
      * @return  string


### PR DESCRIPTION
Add possibility to set wrapper for schema compiler. You can then set wrapper to `%s` if you don't want to create quoted tablenames and column names, but have case insensitive identifiers instead.