### PR TITLE
SQLite compatibility fix

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -56,10 +56,10 @@ class Schema
             $compiler = $this->connection->schemaCompiler();
             $result = $compiler->currentDatabase($this->connection->getDSN());
 
-            if (is_array($result)) {
-                $this->currentDatabase = $this->connection->column($result['sql'], $result['params']);
+            if (isset($result['result'])) {
+                $this->currentDatabase = $result['result'];
             } else {
-                $this->currentDatabase = $result;
+                $this->currentDatabase = $this->connection->column($result['sql'], $result['params']);
             }
         }
 

--- a/src/Schema/Compiler/SQLite.php
+++ b/src/Schema/Compiler/SQLite.php
@@ -114,7 +114,9 @@ class SQLite extends Compiler
      */
     public function currentDatabase(string $dsn): array
     {
-        return substr($dsn, strpos($dsn, ':') + 1);
+        return [
+            'result' => substr($dsn, strpos($dsn, ':') + 1),
+        ];
     }
 
     /**


### PR DESCRIPTION
Classes overriding `Compiler::currentDatabase()` **must** return an array (typically, that array will contain a `sql` element and `params` element, which are used to form a query to determine what the current database is).

For database engines such as SQLite this is not needed—there only ever is one database we can connect to and so we return the filepath instead (which we extract from the DSN). This change simply wraps that up in an array, maintaining compatibility with other db backends and keeping type safety.

This is a possible fix for [issue #58](https://github.com/opis/database/issues/58), though there are other ways we could solve this (including dropping the return type so a straight array can be returned as well as an array, however I felt this approach in this PR had the advantage of keeping type safety).