### PR TITLE
add: 'lazy' method

### DIFF
--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -86,6 +86,24 @@ class ResultSet
     }
 
     /**
+     * Return a generator that fetches each row at a time, reducing memory load.
+     *
+     * @param   int $fetchStyle (optional) PDO fetch style
+     *
+     * @return  iterable
+     */
+    public function lazy($fetchStyle = 0)
+    {
+        $generator = function() use (&$fetchStyle) {
+            while($row = $this->statement->fetch($fetchStyle)) {
+                yield $row;
+            }
+        };
+
+        return $generator();
+    }
+
+    /**
      * Fetch first result
      *
      * @param   callable $callable (optional) Callback function


### PR DESCRIPTION
This method creates a generator that will fetch one row at a time from the data set.
This aims to reduce memory load during ResultSet interation while maintaining the simplicity of "fetchAll" when using it inside a loop.

Here is an example:

```php
$rows = $yourQuery->lazy(PDO::FETCH_ASSOC);

foreach ($rows as $row) {
    echo $row['name'], ' - ', $row['age'];
}
```

Hope you find it useful